### PR TITLE
fix: Correct checkout API route

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
 
   const handlePayment = async () => {
     try {
-      const response = await axios.post('/pages/api/checkout');
+      const response = await axios.post('/api/checkout');
       window.location.href = response.data.url;
     } catch (error) {
       console.error('Payment error:', error);


### PR DESCRIPTION
The payment button was making a request to `/pages/api/checkout`, which was causing a 404 error. This has been corrected to use the correct App Router API route, `/api/checkout`.